### PR TITLE
Rework CitadelGameTest into a pair of attributes.

### DIFF
--- a/Content.IntegrationTests/Tests/_Citadel/Contracts/ContractsTest.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/Contracts/ContractsTest.cs
@@ -7,7 +7,7 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests._Citadel.Contracts;
 
 [TestFixture]
-public sealed class ContractsTest : CitadelGameTest
+public sealed class ContractsTest
 {
     private const string TestContractId = "TESTS_CitadelTestContract";
     private const string TestSignerId = "ToyAmongPequeno"; //Suspicious contractors.
@@ -20,41 +20,44 @@ public sealed class ContractsTest : CitadelGameTest
             - type: CitadelContract
         """;
 
-    [System(Side.Server)]
-    private readonly ContractSystem _sharedContractSys = default!;
-
-    [Test]
-    public async Task Transitions()
+    public sealed class ContractsTestData : GameTestData
     {
-        await Server.WaitAssertion(() =>
+        [System(Side.Server)]
+        public readonly ContractSystem SharedContractSys = default!;
+    }
+
+    [GameTest<ContractsTestData>]
+    public async Task Transitions(ContractsTestData data)
+    {
+        await data.Server.WaitAssertion(() =>
         {
-            var contract = SEntity<CitadelContractComponent>(Spawn(TestContractId));
+            var contract = data.SEntity<CitadelContractComponent>(data.Spawn(TestContractId));
 
             // Nobody has signed on, shouldn't be able to sign it.
             Assert.Multiple(() =>
             {
-                Assert.That(_sharedContractSys.TrySignContract(contract) is TENoPartyA or TENoPartyB);
+                Assert.That(data.SharedContractSys.TrySignContract(contract) is TENoPartyA or TENoPartyB);
                 Assert.That(contract.Comp.State is ContractStateUnsigned);
             });
 
             // Should sign on fine.
             Assert.Multiple(() =>
             {
-                Assert.That(_sharedContractSys.TrySignOn(contract, Spawn(TestSignerId), Party.PartyA));
-                Assert.That(_sharedContractSys.TrySignOn(contract, Spawn(TestSignerId), Party.PartyB));
+                Assert.That(data.SharedContractSys.TrySignOn(contract, data.Spawn(TestSignerId), Party.PartyA));
+                Assert.That(data.SharedContractSys.TrySignOn(contract, data.Spawn(TestSignerId), Party.PartyB));
             });
 
             // And contract should be signable now.
             Assert.Multiple(() =>
             {
-                Assert.That(_sharedContractSys.TrySignContract(contract), Is.Null);
+                Assert.That(data.SharedContractSys.TrySignContract(contract), Is.Null);
                 Assert.That(contract.Comp.State is ContractStateSigned);
             });
 
             // Now we breach it, and blame party B. Poor party B, they're going to owe an amogillion dollars.
             Assert.Multiple(() =>
             {
-                Assert.That(_sharedContractSys.TryBreachContract(contract, Party.PartyB), Is.Null);
+                Assert.That(data.SharedContractSys.TryBreachContract(contract, Party.PartyB), Is.Null);
                 Assert.That(contract.Comp.State is ContractStateBreached { BreachingParty: Party.PartyB });
             });
         });

--- a/Content.IntegrationTests/Tests/_Citadel/Contracts/ContractsTest.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/Contracts/ContractsTest.cs
@@ -1,4 +1,11 @@
-﻿#nullable enable
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, v. 2.0.
+
+#nullable enable
 using Content.Server._Citadel.Contracts;
 using Content.Shared._Citadel.Contracts.Components;
 using Content.Shared._Citadel.Contracts.Systems;

--- a/Content.IntegrationTests/Tests/_Citadel/Contracts/ContractsTest.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/Contracts/ContractsTest.cs
@@ -4,12 +4,10 @@
 //
 // This Source Code Form is "Incompatible With Secondary Licenses", as
 // defined by the Mozilla Public License, v. 2.0.
-
 #nullable enable
 using Content.Server._Citadel.Contracts;
 using Content.Shared._Citadel.Contracts.Components;
 using Content.Shared._Citadel.Contracts.Systems;
-using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests._Citadel.Contracts;
 

--- a/Content.IntegrationTests/Tests/_Citadel/Contracts/ContractsTest.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/Contracts/ContractsTest.cs
@@ -31,7 +31,7 @@ public sealed class ContractsTest
         public readonly ContractSystem SharedContractSys = default!;
     }
 
-    [GameTest<ContractsTestData>]
+    [GameTest<ContractsTestData>(Description = "Checks that contract state transitions function as expected, i.e. with signing, breaching, etc.")]
     public async Task Transitions(ContractsTestData data)
     {
         await data.Server.WaitAssertion(() =>

--- a/Content.IntegrationTests/Tests/_Citadel/Contracts/ContractsTest.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/Contracts/ContractsTest.cs
@@ -31,7 +31,7 @@ public sealed class ContractsTest
     {
         await data.Server.WaitAssertion(() =>
         {
-            var contract = data.SEntity<CitadelContractComponent>(data.Spawn(TestContractId));
+            var contract = data.SEntity<CitadelContractComponent>(data.SSpawn(TestContractId));
 
             // Nobody has signed on, shouldn't be able to sign it.
             Assert.Multiple(() =>
@@ -43,8 +43,8 @@ public sealed class ContractsTest
             // Should sign on fine.
             Assert.Multiple(() =>
             {
-                Assert.That(data.SharedContractSys.TrySignOn(contract, data.Spawn(TestSignerId), Party.PartyA));
-                Assert.That(data.SharedContractSys.TrySignOn(contract, data.Spawn(TestSignerId), Party.PartyB));
+                Assert.That(data.SharedContractSys.TrySignOn(contract, data.SSpawn(TestSignerId), Party.PartyA));
+                Assert.That(data.SharedContractSys.TrySignOn(contract, data.SSpawn(TestSignerId), Party.PartyB));
             });
 
             // And contract should be signable now.

--- a/Content.IntegrationTests/Tests/_Citadel/GameTestAttribute.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/GameTestAttribute.cs
@@ -1,0 +1,264 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Content.IntegrationTests.Pair;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace Content.IntegrationTests.Tests._Citadel;
+
+/// <summary>
+///     Marks a game test, that needs a client and server to run.
+/// </summary>
+/// <typeparam name="TData"></typeparam>
+public sealed class GameTestAttribute<TData> : Attribute, ITestBuilder, IImplyFixture, IApplyToTest
+    where TData: GameTestData, new()
+{
+    /// <summary>
+    ///     An optional description of the test.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    ///     Evil magic that allows us to cleanly wrap a test method.
+    ///     This is used instead of a 'simple' closure because of the need to preserve the object being invoked on.
+    /// </summary>
+    private sealed class TestDataBasedWrapper(IMethodInfo inner) : IMethodInfo
+    {
+        public T[] GetCustomAttributes<T>(bool inherit) where T : class
+        {
+            return Array.Empty<T>();
+        }
+
+        public bool IsDefined<T>(bool inherit) where T : class
+        {
+            return false;
+        }
+
+        public IParameterInfo[] GetParameters()
+        {
+            return Array.Empty<IParameterInfo>();
+        }
+
+        public Type[] GetGenericArguments()
+        {
+            return Array.Empty<Type>();
+        }
+
+        public IMethodInfo MakeGenericMethod(params Type[] typeArguments)
+        {
+            throw new NotSupportedException();
+        }
+
+        public object Invoke(object fixture, params object[] args)
+        {
+            return InnerInvoke(fixture);
+        }
+
+        private async Task InnerInvoke(object fixture)
+        {
+            // We don't use the fixture at all..
+            var data = new TData();
+
+            await data.DoSetup();
+
+            if (inner.ReturnType.IsType(typeof(Task)))
+            {
+                await (Task)inner.Invoke(fixture, data)!;
+            }
+            else
+            {
+                inner.Invoke(fixture, data);
+            }
+
+            await data.DoTeardown();
+        }
+
+        public ITypeInfo TypeInfo => new TypeWrapper(((Func<Task>)(HackToLookAsync)).GetType());
+        public MethodInfo MethodInfo => ((Func<Task>)(HackToLookAsync)).Method;
+        public string Name => inner.Name;
+        public bool IsAbstract => false;
+        public bool IsPublic => true;
+        public bool IsStatic => false;
+        public bool ContainsGenericParameters => false;
+        public bool IsGenericMethod => false;
+        public bool IsGenericMethodDefinition => false;
+        public ITypeInfo ReturnType => new TypeWrapper(typeof(void));
+
+        private Task HackToLookAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
+    {
+        var innerParams = method.GetParameters();
+
+        if (innerParams.Length == 1 && innerParams[0].ParameterType.IsAssignableTo(typeof(GameTestData)))
+        {
+            var wrapper = new TestDataBasedWrapper(method);
+
+            return new[] { new TestMethod(wrapper, null) };
+        }
+        else
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    public void ApplyToTest(Test test)
+    {
+        if (!test.Properties.ContainsKey(PropertyNames.Description) && Description is not null)
+            test.Properties.Set(PropertyNames.Description, Description);
+    }
+}
+
+public sealed class DirtyFlag
+{
+    public bool IsDirty { get; private set; }
+
+    public void Set() => IsDirty = true;
+}
+
+/// <summary>
+///     A simpler version of the generic GameTestAttribute that allows you to specify what you need with just arguments.
+/// </summary>
+public sealed class GameTestAttribute : Attribute, ITestBuilder, IImplyFixture, IApplyToTest
+{
+    /// <summary>
+    ///     An optional description of the test.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    ///     Evil magic that allows us to cleanly wrap a test method.
+    ///     This is used instead of a 'simple' closure because of the need to preserve the object being invoked on.
+    /// </summary>
+    private sealed class AttributeBasedWrapper(IMethodInfo inner) : IMethodInfo
+    {
+        public T[] GetCustomAttributes<T>(bool inherit) where T : class
+        {
+            return Array.Empty<T>();
+        }
+
+        public bool IsDefined<T>(bool inherit) where T : class
+        {
+            return false;
+        }
+
+        public IParameterInfo[] GetParameters()
+        {
+            return Array.Empty<IParameterInfo>();
+        }
+
+        public Type[] GetGenericArguments()
+        {
+            return Array.Empty<Type>();
+        }
+
+        public IMethodInfo MakeGenericMethod(params Type[] typeArguments)
+        {
+            throw new NotSupportedException();
+        }
+
+        public object Invoke(object fixture, params object[] args)
+        {
+            return InnerInvoke(fixture);
+        }
+
+        private async Task InnerInvoke(object fixture)
+        {
+            var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+
+            var args = new List<object>();
+
+            var dirty = new DirtyFlag();
+
+            foreach (var param in inner.GetParameters())
+            {
+                if (param.GetCustomAttributes<SidedDependencyAttribute>(false) is [var dependencyAttribute])
+                {
+                    if (dependencyAttribute.Side is Side.Server)
+                    {
+                        args.Add(pair.Server.InstanceDependencyCollection.ResolveType(param.ParameterType));
+                    }
+                    else
+                    {
+                        args.Add(pair.Client.InstanceDependencyCollection.ResolveType(param.ParameterType));
+                    }
+                }
+                else if (param.GetCustomAttributes<SystemAttribute>(false) is [var systemAttribute])
+                {
+                    if (systemAttribute.Side is Side.Server)
+                    {
+                        args.Add(pair.Server.EntMan.EntitySysManager.GetEntitySystem(param.ParameterType));
+                    }
+                    else
+                    {
+                        args.Add(pair.Client.EntMan.EntitySysManager.GetEntitySystem(param.ParameterType));
+                    }
+                }
+                else if (param.ParameterType == typeof(TestPair))
+                {
+                    args.Add(pair);
+                }
+                else if (param.ParameterType == typeof(DirtyFlag))
+                {
+                    args.Add(dirty);
+                }
+            }
+
+            if (inner.ReturnType.IsType(typeof(Task)))
+            {
+                await (Task)inner.Invoke(fixture, args.ToArray())!;
+            }
+            else
+            {
+                inner.Invoke(fixture, args.ToArray());
+            }
+
+            if (!dirty.IsDirty)
+                await pair.CleanReturnAsync();
+            else
+                await pair.DisposeAsync();
+        }
+
+        public ITypeInfo TypeInfo => new TypeWrapper(((Func<Task>)(HackToLookAsync)).GetType());
+        public MethodInfo MethodInfo => ((Func<Task>)(HackToLookAsync)).Method;
+        public string Name => inner.Name;
+        public bool IsAbstract => false;
+        public bool IsPublic => true;
+        public bool IsStatic => false;
+        public bool ContainsGenericParameters => false;
+        public bool IsGenericMethod => false;
+        public bool IsGenericMethodDefinition => false;
+        public ITypeInfo ReturnType => new TypeWrapper(typeof(void));
+
+        private Task HackToLookAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
+    {
+        var innerParams = method.GetParameters();
+
+        if (innerParams.Length == 1 && innerParams[0].ParameterType.IsAssignableTo(typeof(GameTestData)))
+        {
+            throw new NotSupportedException();
+        }
+        else
+        {
+            var wrapper = new AttributeBasedWrapper(method);
+
+            return new[] { new TestMethod(wrapper, null) };
+        }
+    }
+
+    public void ApplyToTest(Test test)
+    {
+        if (!test.Properties.ContainsKey(PropertyNames.Description) && Description is not null)
+            test.Properties.Set(PropertyNames.Description, Description);
+    }
+}

--- a/Content.IntegrationTests/Tests/_Citadel/GameTestAttribute.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/GameTestAttribute.cs
@@ -61,16 +61,26 @@ public sealed class GameTestAttribute<TData> : Attribute, ITestBuilder, IImplyFi
 
             await data.DoSetup();
 
-            if (inner.ReturnType.IsType(typeof(Task)))
+            try
             {
-                await (Task)inner.Invoke(fixture, data)!;
+                if (inner.ReturnType.IsType(typeof(Task)))
+                {
+                    await (Task)inner.Invoke(fixture, data)!;
+                }
+                else
+                {
+                    inner.Invoke(fixture, data);
+                }
             }
-            else
+            catch (Exception)
             {
-                inner.Invoke(fixture, data);
+                data.MarkDirty();
+                throw;
             }
-
-            await data.DoTeardown();
+            finally
+            {
+                await data.DoTeardown();
+            }
         }
 
         public ITypeInfo TypeInfo => new TypeWrapper(((Func<Task>)(HackToLookAsync)).GetType());
@@ -208,19 +218,29 @@ public sealed class GameTestAttribute : Attribute, ITestBuilder, IImplyFixture, 
                 }
             }
 
-            if (inner.ReturnType.IsType(typeof(Task)))
+            try
             {
-                await (Task)inner.Invoke(fixture, args.ToArray())!;
+                if (inner.ReturnType.IsType(typeof(Task)))
+                {
+                    await (Task)inner.Invoke(fixture, args.ToArray())!;
+                }
+                else
+                {
+                    inner.Invoke(fixture, args.ToArray());
+                }
             }
-            else
+            catch (Exception)
             {
-                inner.Invoke(fixture, args.ToArray());
+                dirty.Set();
+                throw;
             }
-
-            if (!dirty.IsDirty)
-                await pair.CleanReturnAsync();
-            else
-                await pair.DisposeAsync();
+            finally
+            {
+                if (!dirty.IsDirty)
+                    await pair.CleanReturnAsync();
+                else
+                    await pair.DisposeAsync();
+            }
         }
 
         public ITypeInfo TypeInfo => new TypeWrapper(((Func<Task>)(HackToLookAsync)).GetType());

--- a/Content.IntegrationTests/Tests/_Citadel/GameTestAttribute.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/GameTestAttribute.cs
@@ -4,7 +4,7 @@
 //
 // This Source Code Form is "Incompatible With Secondary Licenses", as
 // defined by the Mozilla Public License, v. 2.0.
-
+#nullable enable
 using System.Collections.Generic;
 using System.Reflection;
 using Content.IntegrationTests.Pair;
@@ -56,12 +56,12 @@ public sealed class GameTestAttribute<TData> : Attribute, ITestBuilder, IImplyFi
             throw new NotSupportedException();
         }
 
-        public object Invoke(object fixture, params object[] args)
+        public object Invoke(object? fixture, params object?[]? args)
         {
             return InnerInvoke(fixture);
         }
 
-        private async Task InnerInvoke(object fixture)
+        private async Task InnerInvoke(object? fixture)
         {
             // We don't use the fixture at all..
             var data = new TData();
@@ -107,7 +107,7 @@ public sealed class GameTestAttribute<TData> : Attribute, ITestBuilder, IImplyFi
         }
     }
 
-    public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
+    public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test? suite)
     {
         var innerParams = method.GetParameters();
 
@@ -178,12 +178,12 @@ public sealed class GameTestAttribute : Attribute, ITestBuilder, IImplyFixture, 
             throw new NotSupportedException();
         }
 
-        public object Invoke(object fixture, params object[] args)
+        public object Invoke(object? fixture, params object?[]? args)
         {
             return InnerInvoke(fixture);
         }
 
-        private async Task InnerInvoke(object fixture)
+        private async Task InnerInvoke(object? fixture)
         {
             var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
 
@@ -267,7 +267,7 @@ public sealed class GameTestAttribute : Attribute, ITestBuilder, IImplyFixture, 
         }
     }
 
-    public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
+    public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test? suite)
     {
         var innerParams = method.GetParameters();
 

--- a/Content.IntegrationTests/Tests/_Citadel/GameTestAttribute.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/GameTestAttribute.cs
@@ -8,6 +8,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using Content.IntegrationTests.Pair;
+using JetBrains.Annotations;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
@@ -17,6 +18,7 @@ namespace Content.IntegrationTests.Tests._Citadel;
 ///     Marks a game test, that needs a client and server to run.
 /// </summary>
 /// <typeparam name="TData"></typeparam>
+[MeansImplicitUse]
 public sealed class GameTestAttribute<TData> : Attribute, ITestBuilder, IImplyFixture, IApplyToTest
     where TData: GameTestData, new()
 {
@@ -140,6 +142,7 @@ public sealed class DirtyFlag
 /// <summary>
 ///     A simpler version of the generic GameTestAttribute that allows you to specify what you need with just arguments.
 /// </summary>
+[MeansImplicitUse]
 public sealed class GameTestAttribute : Attribute, ITestBuilder, IImplyFixture, IApplyToTest
 {
     /// <summary>

--- a/Content.IntegrationTests/Tests/_Citadel/GameTestAttribute.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/GameTestAttribute.cs
@@ -1,3 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, v. 2.0.
+
 using System.Collections.Generic;
 using System.Reflection;
 using Content.IntegrationTests.Pair;

--- a/Content.IntegrationTests/Tests/_Citadel/GameTestAttribute.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/GameTestAttribute.cs
@@ -17,8 +17,9 @@ namespace Content.IntegrationTests.Tests._Citadel;
 /// <summary>
 ///     Marks a game test, that needs a client and server to run.
 /// </summary>
-/// <typeparam name="TData"></typeparam>
+/// <typeparam name="TData">The GameTestData inheriter to use.</typeparam>
 [MeansImplicitUse]
+[PublicAPI]
 public sealed class GameTestAttribute<TData> : Attribute, ITestBuilder, IImplyFixture, IApplyToTest
     where TData: GameTestData, new()
 {
@@ -143,6 +144,7 @@ public sealed class DirtyFlag
 ///     A simpler version of the generic GameTestAttribute that allows you to specify what you need with just arguments.
 /// </summary>
 [MeansImplicitUse]
+[PublicAPI]
 public sealed class GameTestAttribute : Attribute, ITestBuilder, IImplyFixture, IApplyToTest
 {
     /// <summary>

--- a/Content.IntegrationTests/Tests/_Citadel/GameTestData.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/GameTestData.cs
@@ -8,6 +8,7 @@
 #nullable enable
 using System.Reflection;
 using Content.IntegrationTests.Pair;
+using JetBrains.Annotations;
 using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Player;
@@ -21,26 +22,58 @@ namespace Content.IntegrationTests.Tests._Citadel;
 ///     Can also be used in lieu of a parent class if you don't need much.
 /// </summary>
 [Virtual]
+[PublicAPI]
 public class GameTestData
 {
     private bool _pairDirty = false;
 
+    /// <summary>
+    ///     Settings for the client/server pair. By default, this gets you a client and server that have connected together.
+    /// </summary>
+    public virtual PoolSettings PoolSettings => new() { Connected = true };
+
+    /// <summary>
+    ///     The client and server pair.
+    /// </summary>
     public TestPair Pair { get; private set; } = default!; // NULLABILITY: This is always set during test setup.
+    /// <summary>
+    ///     The game server instance.
+    /// </summary>
     public RobustIntegrationTest.ServerIntegrationInstance Server => Pair.Server;
+    /// <summary>
+    ///     The game client instance.
+    /// </summary>
     public RobustIntegrationTest.ClientIntegrationInstance Client => Pair.Client;
+
+    /// <summary>
+    ///     The test player, if any.
+    /// </summary>
     public ICommonSession? Player => Pair.Player;
 
+    /// <summary>
+    ///     The server-side entity manager.
+    /// </summary>
     public IEntityManager SEntMan => Server.EntMan;
+    /// <summary>
+    ///     The client-side entity manager.
+    /// </summary>
+    public IEntityManager CEntMan => Server.EntMan;
 
+    /// <summary>
+    ///     Marks the test pair as dirty, ensuring it is returned as such.
+    /// </summary>
     public void MarkDirty()
     {
         _pairDirty = true;
     }
 
+    /// <summary>
+    ///     Internal function to do initial setup. Don't use this..
+    /// </summary>
     public async Task DoSetup()
     {
         _pairDirty = false;
-        Pair = await PoolManager.GetServerClient(new PoolSettings {Connected = true});
+        Pair = await PoolManager.GetServerClient(PoolSettings);
 
         foreach (var field in GetType().GetAllFields())
         {
@@ -71,6 +104,9 @@ public class GameTestData
         }
     }
 
+    /// <summary>
+    ///     Internal function to do post-test teardown. Don't use this..
+    /// </summary>
     public async Task DoTeardown()
     {
         if (!_pairDirty)
@@ -79,36 +115,89 @@ public class GameTestData
             await Pair.DisposeAsync();
     }
 
+    /// <summary>
+    ///     Converts a server EntityUid into the client-side equivalent entity.
+    /// </summary>
     public EntityUid ToClientUid(EntityUid serverUid)
     {
         return Pair.ToClientUid(serverUid);
     }
 
+    /// <summary>
+    ///     Converts a client EntityUid into the server-side equivalent entity.
+    /// </summary>
     public EntityUid ToServerUid(EntityUid clientUid)
     {
         return Pair.ToServerUid(clientUid);
     }
 
+    /// <summary>
+    ///     Retrieves the given entitysystem from the server.
+    /// </summary>
     public T GetSysServer<T>()
         where T : EntitySystem
     {
         return Server.EntMan.System<T>();
     }
 
+    /// <summary>
+    ///     Retrieves the given entitysystem from the client.
+    /// </summary>
+    public T GetSysClient<T>()
+        where T : EntitySystem
+    {
+        return Client.EntMan.System<T>();
+    }
+
+    /// <summary>
+    ///     Retrieves the given component from an entity, from the server.
+    /// </summary>
     public T SComp<T>(EntityUid target)
         where T : IComponent
     {
         return SEntMan.GetComponent<T>(target);
     }
 
+    /// <summary>
+    ///     Retrieves the given component from an entity, from the client.
+    /// </summary>
+    public T CComp<T>(EntityUid target)
+        where T : IComponent
+    {
+        return CEntMan.GetComponent<T>(target);
+    }
+
+    /// <summary>
+    ///     Pairs an EntityUid with the given component, from the server.
+    /// </summary>
     public Entity<T> SEntity<T>(EntityUid target)
         where T : IComponent
     {
         return new(target, SEntMan.GetComponent<T>(target));
     }
 
-    public EntityUid Spawn(string id)
+    /// <summary>
+    ///     Pairs an EntityUid with the given component, from the client.
+    /// </summary>
+    public Entity<T> CEntity<T>(EntityUid target)
+        where T : IComponent
+    {
+        return new(target, CEntMan.GetComponent<T>(target));
+    }
+
+    /// <summary>
+    ///     Spawns an entity on the server.
+    /// </summary>
+    public EntityUid SSpawn(string id)
     {
         return SEntMan.Spawn(id);
+    }
+
+    /// <summary>
+    ///     Spawns an entity on the client.
+    /// </summary>
+    public EntityUid CSpawn(string id)
+    {
+        return CEntMan.Spawn(id);
     }
 }

--- a/Content.IntegrationTests/Tests/_Citadel/GameTestData.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/GameTestData.cs
@@ -1,7 +1,14 @@
-﻿#nullable enable
-using System.Linq;
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, v. 2.0.
+
+#nullable enable
 using System.Reflection;
 using Content.IntegrationTests.Pair;
+using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
@@ -9,24 +16,28 @@ using Robust.UnitTesting;
 
 namespace Content.IntegrationTests.Tests._Citadel;
 
-public abstract class CitadelGameTest
+/// <summary>
+///     A base class for data automatically injected by a game test.
+///     Can also be used in lieu of a parent class if you don't need much.
+/// </summary>
+[Virtual]
+public class GameTestData
 {
     private bool _pairDirty = false;
 
-    protected TestPair Pair = default!; // NULLABILITY: This is always set during test setup.
-    protected RobustIntegrationTest.ServerIntegrationInstance Server => Pair.Server;
-    protected RobustIntegrationTest.ClientIntegrationInstance Client => Pair.Client;
-    protected ICommonSession? Player => Pair.Player;
+    public TestPair Pair { get; private set; } = default!; // NULLABILITY: This is always set during test setup.
+    public RobustIntegrationTest.ServerIntegrationInstance Server => Pair.Server;
+    public RobustIntegrationTest.ClientIntegrationInstance Client => Pair.Client;
+    public ICommonSession? Player => Pair.Player;
 
-    protected IEntityManager SEntMan => Server.EntMan;
+    public IEntityManager SEntMan => Server.EntMan;
 
-    protected void DirtyClientServerPair()
+    public void MarkDirty()
     {
         _pairDirty = true;
     }
 
-    [SetUp]
-    public virtual async Task Setup()
+    public async Task DoSetup()
     {
         _pairDirty = false;
         Pair = await PoolManager.GetServerClient(new PoolSettings {Connected = true});
@@ -60,8 +71,7 @@ public abstract class CitadelGameTest
         }
     }
 
-    [TearDown]
-    public virtual async Task TearDown()
+    public async Task DoTeardown()
     {
         if (!_pairDirty)
             await Pair.CleanReturnAsync();
@@ -69,41 +79,35 @@ public abstract class CitadelGameTest
             await Pair.DisposeAsync();
     }
 
-    protected EntityUid ToClientUid(EntityUid serverUid)
+    public EntityUid ToClientUid(EntityUid serverUid)
     {
         return Pair.ToClientUid(serverUid);
     }
 
-    protected EntityUid ToServerUid(EntityUid clientUid)
+    public EntityUid ToServerUid(EntityUid clientUid)
     {
         return Pair.ToServerUid(clientUid);
     }
 
-    protected T GetSysServer<T>()
+    public T GetSysServer<T>()
         where T : EntitySystem
     {
         return Server.EntMan.System<T>();
     }
 
-    protected T GetSysClient<T>()
-        where T : EntitySystem
-    {
-        return Client.EntMan.System<T>();
-    }
-
-    protected T SComp<T>(EntityUid target)
+    public T SComp<T>(EntityUid target)
         where T : IComponent
     {
         return SEntMan.GetComponent<T>(target);
     }
 
-    protected Entity<T> SEntity<T>(EntityUid target)
+    public Entity<T> SEntity<T>(EntityUid target)
         where T : IComponent
     {
         return new(target, SEntMan.GetComponent<T>(target));
     }
 
-    protected EntityUid Spawn(string id)
+    public EntityUid Spawn(string id)
     {
         return SEntMan.Spawn(id);
     }

--- a/Content.IntegrationTests/Tests/_Citadel/GameTestData.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/GameTestData.cs
@@ -25,7 +25,7 @@ namespace Content.IntegrationTests.Tests._Citadel;
 [PublicAPI]
 public class GameTestData
 {
-    private bool _pairDirty = false;
+    private bool _pairDirty;
 
     /// <summary>
     ///     Settings for the client/server pair. By default, this gets you a client and server that have connected together.

--- a/Content.IntegrationTests/Tests/_Citadel/SystemAttribute.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/SystemAttribute.cs
@@ -1,4 +1,11 @@
-﻿namespace Content.IntegrationTests.Tests._Citadel;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, v. 2.0.
+
+namespace Content.IntegrationTests.Tests._Citadel;
 
 /// <summary>
 ///     Marks a field on a CitadelGameTest inheritor as needing to be populated with a system from the given side.

--- a/Content.IntegrationTests/Tests/_Citadel/Utilities/SmallRandomTests.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/Utilities/SmallRandomTests.cs
@@ -46,12 +46,12 @@ public sealed class SmallRandomTests
     }
 
     [GameTest]
-    public void Serialize([SidedDependency(Side.Server)] ISerializationManager _ser)
+    public void Serialize([SidedDependency(Side.Server)] ISerializationManager ser)
     {
         Assert.That(SmallRandom.TryFromStringAsSeed("colon-three", out var myRandomNullable));
         var myRandom = myRandomNullable!.Value;
 
-        var node = (MappingDataNode)_ser.WriteValue(new SmallRandomTestSer(myRandom));
+        var node = (MappingDataNode)ser.WriteValue(new SmallRandomTestSer(myRandom));
         var document = new YamlStream {new(node.ToYaml())};
         var writer = new StringWriter();
         document.Save(writer);
@@ -62,7 +62,7 @@ public sealed class SmallRandomTests
 
         var mapping = (MappingDataNode) readDocument.Root;
 
-        var parsedMyRandom = _ser.Read<SmallRandomTestSer>(mapping).MyRandom;
+        var parsedMyRandom = ser.Read<SmallRandomTestSer>(mapping).MyRandom;
 
         Assert.That(myRandom.DebugCheckByteEquality(ref parsedMyRandom));
     }

--- a/Content.IntegrationTests/Tests/_Citadel/Utilities/SmallRandomTests.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/Utilities/SmallRandomTests.cs
@@ -45,7 +45,7 @@ public sealed class SmallRandomTests
         Assert.That(myRandom.Next() != myRandom.Next());
     }
 
-    [GameTest]
+    [GameTest(Description = "Serializes a SmallRandom and then deserializes it again with YAML serialization, asserting that it remains the same over a round trip.")]
     public void Serialize([SidedDependency(Side.Server)] ISerializationManager ser)
     {
         Assert.That(SmallRandom.TryFromStringAsSeed("colon-three", out var myRandomNullable));

--- a/Content.IntegrationTests/Tests/_Citadel/Utilities/SmallRandomTests.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/Utilities/SmallRandomTests.cs
@@ -44,15 +44,9 @@ public sealed class SmallRandomTests
         Assert.That(myRandom.Next() != myRandom.Next());
         Assert.That(myRandom.Next() != myRandom.Next());
     }
-}
 
-public sealed class SmallRandomSerTest : CitadelGameTest
-{
-    [SidedDependency(Side.Server)]
-    private readonly ISerializationManager _ser = default!;
-
-    [Test]
-    public void Serialize()
+    [GameTest]
+    public void Serialize([SidedDependency(Side.Server)] ISerializationManager _ser)
     {
         Assert.That(SmallRandom.TryFromStringAsSeed("colon-three", out var myRandomNullable));
         var myRandom = myRandomNullable!.Value;
@@ -73,7 +67,6 @@ public sealed class SmallRandomSerTest : CitadelGameTest
         Assert.That(myRandom.DebugCheckByteEquality(ref parsedMyRandom));
     }
 }
-
 
 [DataDefinition]
 public sealed partial class SmallRandomTestSer


### PR DESCRIPTION
This allows you to freely intersperse normal unit tests and GameTests, alongside allowing them to properly run in parallel.

This is an internal change, no further information is needed aside from the documentation written.